### PR TITLE
feat: add futures and index quote support

### DIFF
--- a/tasty_agent/server.py
+++ b/tasty_agent/server.py
@@ -38,15 +38,23 @@ async def _stream_events(
     timeout: float
 ) -> list[Any]:
     """Generic streaming helper for Quote/Greeks events."""
+    events_by_symbol: dict[str, Any] = {}
+    expected = set(streamer_symbols)
     async with DXLinkStreamer(session) as streamer:
         await streamer.subscribe(event_type, streamer_symbols)
-        events_by_symbol: dict[str, Any] = {}
-        expected = set(streamer_symbols)
-        while len(events_by_symbol) < len(expected):
-            event = await asyncio.wait_for(streamer.get_event(event_type), timeout=timeout)
-            if event.event_symbol in expected:
-                events_by_symbol[event.event_symbol] = event
-        return [events_by_symbol[s] for s in streamer_symbols]
+        try:
+            async with asyncio.timeout(timeout):
+                while len(events_by_symbol) < len(expected):
+                    event = await streamer.get_event(event_type)
+                    if event.event_symbol in expected:
+                        events_by_symbol[event.event_symbol] = event
+        except TimeoutError:
+            missing = expected - set(events_by_symbol)
+            raise ValueError(
+                f"Timeout getting quotes after {timeout}s. "
+                f"No data received for: {sorted(missing)}"
+            )
+    return [events_by_symbol[s] for s in streamer_symbols]
 
 
 async def _paginate[T](
@@ -165,7 +173,7 @@ async def get_net_liquidating_value_history(
 class InstrumentDetail:
     """Details for a resolved instrument."""
     streamer_symbol: str
-    instrument: Equity | Option | Future | None
+    instrument: Equity | Option | Future
 
 
 class InstrumentSpec(BaseModel):
@@ -270,7 +278,10 @@ async def get_instrument_details(session: Session, instrument_specs: list[Instru
             return InstrumentDetail(instrument.streamer_symbol, instrument)
 
         elif resolved_type == InstrumentType.INDEX:
-            return InstrumentDetail(symbol, None)
+            # Indices (SPX, VIX, etc.) are equities with is_index=True in the API.
+            # We must fetch via Equity.get() to obtain the correct streamer_symbol.
+            instrument = await Equity.get(session, symbol)
+            return InstrumentDetail(instrument.streamer_symbol, instrument)
 
         else:
             # Get equity instrument
@@ -316,10 +327,7 @@ async def get_quotes(
     session = get_session(ctx)
     instrument_details = await get_instrument_details(session, instruments)
 
-    try:
-        quotes = await _stream_events(session, Quote, [d.streamer_symbol for d in instrument_details], timeout)
-    except TimeoutError as e:
-        raise ValueError(f"Timeout getting quotes for {len(instruments)} instruments after {timeout}s") from e
+    quotes = await _stream_events(session, Quote, [d.streamer_symbol for d in instrument_details], timeout)
     return to_table(quotes)
 
 
@@ -353,10 +361,7 @@ async def get_greeks(
     session = get_session(ctx)
     option_details = await get_instrument_details(session, options)
 
-    try:
-        greeks = await _stream_events(session, Greeks, [d.streamer_symbol for d in option_details], timeout)
-    except TimeoutError as e:
-        raise ValueError(f"Timeout getting Greeks for {len(options)} options after {timeout}s") from e
+    greeks = await _stream_events(session, Greeks, [d.streamer_symbol for d in option_details], timeout)
     return to_table(greeks)
 
 
@@ -495,8 +500,8 @@ def build_order_legs(instrument_details: list[InstrumentDetail], legs: list[Orde
     built_legs = []
     for detail, leg_spec in zip(instrument_details, legs, strict=True):
         instrument = detail.instrument
-        if instrument is None:
-            raise ValueError(f"Cannot place orders for index symbols (streamer-only)")
+        if isinstance(instrument, Equity) and instrument.is_index:
+            raise ValueError(f"Cannot place orders for index symbol '{detail.streamer_symbol}' (quote-only)")
         if isinstance(instrument, (Option, Future)):
             order_action = OrderAction(leg_spec.action)
         else:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,8 @@
 """Unit tests for tasty_agent.server module."""
 
+import asyncio
 from datetime import UTC, date, datetime
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from tastytrade.market_sessions import MarketStatus
@@ -13,6 +14,7 @@ from tasty_agent.server import (
     WatchlistSymbol,
     _get_next_open_time,
     _option_chain_key_builder,
+    _stream_events,
     build_order_legs,
     to_table,
     validate_date_format,
@@ -208,3 +210,57 @@ class TestInstrumentDetail:
         detail = InstrumentDetail("AAPL", mock_instrument)
         assert detail.streamer_symbol == "AAPL"
         assert detail.instrument == mock_instrument
+
+
+class TestStreamEvents:
+    """Tests for _stream_events timeout handling (issue #12)."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_valueerror_not_exceptiongroup(self):
+        """Verify timeout produces a clean ValueError, not an ExceptionGroup."""
+        mock_session = Mock()
+
+        mock_streamer = AsyncMock()
+        mock_streamer.__aenter__ = AsyncMock(return_value=mock_streamer)
+        mock_streamer.__aexit__ = AsyncMock(return_value=False)
+        mock_streamer.subscribe = AsyncMock()
+
+        async def block_forever(_):
+            await asyncio.sleep(999)
+        mock_streamer.get_event = block_forever
+
+        with patch("tasty_agent.server.DXLinkStreamer", return_value=mock_streamer):
+            with pytest.raises(ValueError, match="Timeout getting quotes after"):
+                from tastytrade.dxfeed import Quote
+                await _stream_events(mock_session, Quote, ["AAPL"], timeout=0.1)
+
+    @pytest.mark.asyncio
+    async def test_returns_events_in_order(self):
+        """Verify events are returned in the same order as input symbols."""
+        mock_session = Mock()
+
+        event_a = Mock()
+        event_a.event_symbol = "AAPL"
+        event_b = Mock()
+        event_b.event_symbol = "TSLA"
+
+        events = [event_b, event_a]
+        call_count = 0
+
+        async def fake_get_event(_):
+            nonlocal call_count
+            event = events[call_count]
+            call_count += 1
+            return event
+
+        mock_streamer = AsyncMock()
+        mock_streamer.__aenter__ = AsyncMock(return_value=mock_streamer)
+        mock_streamer.__aexit__ = AsyncMock(return_value=False)
+        mock_streamer.subscribe = AsyncMock()
+        mock_streamer.get_event = fake_get_event
+
+        with patch("tasty_agent.server.DXLinkStreamer", return_value=mock_streamer):
+            from tastytrade.dxfeed import Quote
+            result = await _stream_events(mock_session, Quote, ["AAPL", "TSLA"], timeout=5.0)
+
+        assert result == [event_a, event_b]


### PR DESCRIPTION
## Summary
- Adds futures quote support to `get_quotes` — auto-detected via `/` prefix (e.g., `/ESM26`, `/VXJ26`)
- Adds index quote support — requires `instrument_type: "Index"` (e.g., `SPX`, `VIX`, `NDX`)
- Extends `place_order` to support futures trading
- Uses `InstrumentType` enum for type-safe instrument dispatch

## Usage

```python
# Futures (auto-detected)
get_quotes([{"symbol": "/ESM26"}])

# Index (explicit type required — looks like equity otherwise)
get_quotes([{"symbol": "SPX", "instrument_type": "Index"}])

# Mixed
get_quotes([{"symbol": "AAPL"}, {"symbol": "/ESM26"}, {"symbol": "VIX", "instrument_type": "Index"}])
```

## Test plan
- [ ] Verify futures quotes return data: `/ESM26`, `/VXJ26`
- [ ] Verify index quotes return data: `SPX`, `VIX`, `NDX`
- [ ] Verify existing equity quotes still work: `AAPL`, `TQQQ`
- [ ] Verify existing option quotes still work
- [ ] Verify mixed queries (equity + futures + index) work in a single call
- [ ] Verify `place_order` works with futures symbols

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)