### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ uv run examples/mcp_client.py get_market_metrics '{"symbols": ["AAPL", "SPY"]}'
 
 See [`examples/mcp_client.py`](examples/mcp_client.py) for the full client code.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ferdousbhai-tasty-agent).
+
 ## Examples
 
 ```


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/ferdousbhai-tasty-agent).