### PR TITLE
feat: improve trading skill score from 18% to 90%

### DIFF
--- a/skills/trading/SKILL.md
+++ b/skills/trading/SKILL.md
@@ -1,14 +1,30 @@
 ---
-description: Triggers on TastyTrade account queries, trading, positions, orders, options analysis.
+name: trading
+description: "Manage TastyTrade brokerage accounts — monitor portfolios, analyze options with Greeks and GEX, place and manage multi-leg orders, and stream real-time market data. Use when the user asks about account balances, positions, options chains, IV rank, gamma exposure, order placement, watchlists, or market status."
 ---
 
 # TastyTrade Trading
 
-The **tasty-agent** MCP server connects to TastyTrade brokerage. Tools are self-documenting.
+Interact with TastyTrade brokerage accounts via the tasty-agent MCP server. Covers portfolio monitoring, market data streaming, options analysis, and order management with built-in rate limiting (2 req/s).
 
-## Guidelines
+## Workflow
 
-- Check market_status before placing orders
-- Verify positions before suggesting trades
-- Options: always check Greeks (get_greeks) for risk assessment
-- Order placement requires explicit user confirmation
+1. **Check market status** — call `market_status` to confirm the relevant exchange is open before placing orders or fetching live quotes.
+2. **Review account state** — use `account_overview` with `include=["balances","positions"]` to see net liquidating value and current holdings.
+3. **Research** — gather data with the appropriate tool:
+   - `get_quotes` for real-time stock/option/futures quotes via DXLink streaming
+   - `get_greeks` for delta, gamma, theta, vega, rho on specific option contracts
+   - `get_gex` for gamma exposure analysis (net GEX, flip level, call/put walls)
+   - `get_market_metrics` for IV rank, IV percentile, beta, and liquidity across symbols
+   - `search_symbols` to look up tickers by name
+4. **Plan the trade** — verify positions with `account_overview`, check Greeks for risk, and confirm the user's intent before proceeding.
+5. **Execute** — use `manage_order` with `action="place"` for new orders (supports multi-leg, auto mid-price discovery), `action="replace"` to modify price, or `action="cancel"` to cancel. Always require explicit user confirmation before placing.
+6. **Track** — use `get_history` for transaction or order history, `manage_order` with `action="list"` for live orders, and `watchlist` to manage symbol lists.
+
+## Key Rules
+
+- Never place orders without explicit user confirmation.
+- Equity and option legs use `Buy to Open`, `Buy to Close`, `Sell to Open`, `Sell to Close`; futures use `Buy` or `Sell`.
+- Supported time-in-force values: `Day`, `GTC`, `GTD`, `Ext`, `Ext Overnight`, `GTC Ext`, `GTC Ext Overnight`, `IOC`.
+- `get_gex` returns compact analysis (not raw per-strike data) to avoid oversized responses on large chains.
+- Use `get_history(type="transactions")` for trade/money history (default 90 days) and `type="orders"` for order history (default 7 days). Paginate with `page_offset` and `max_results`.


### PR DESCRIPTION
Hey @ferdousbhai 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. Here's the full before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| trading | 18% | 90% | +72% |

The `trading` skill was the only skill in the repo, so this PR covers the full set.

<details>
<summary>What changed</summary>

- **Added missing `name` field** in frontmatter — this was blocking deterministic validation (the main reason for the 18% score)
- **Expanded the description** with specific trigger terms (account balances, positions, options chains, IV rank, gamma exposure, order placement, watchlists, market status) and a clear "Use when..." clause
- **Replaced generic guidelines with a structured 6-step workflow** — check market status → review account → research → plan → execute → track — mapping each step to the actual MCP tool names and parameters
- **Added Key Rules section** with concrete details: order action verbs, supported time-in-force values, pagination guidance, and the explicit user-confirmation requirement
- **Preserved all domain expertise** — no trading logic was changed, just how the skill surfaces it to the agent

</details>

---

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@rohan-tessl](https://github.com/rohan-tessl) - if you hit any snags.

Thanks in advance 🙏
