### PR TITLE
Feat/compact strike match refactor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # tasty-agent
 
-TastyTrade MCP server (Python/FastMCP). Exposes 12 tools for portfolio management, trading, and market data via Model Context Protocol.
+TastyTrade MCP server (Python/FastMCP). Exposes 13 tools for portfolio management, trading, and market data via Model Context Protocol.
 
 ## Architecture
 
@@ -13,7 +13,7 @@ TastyTrade MCP server (Python/FastMCP). Exposes 12 tools for portfolio managemen
 - **Output shape**: Tools return compact tables/dicts with selected actionable fields instead of full SDK dumps
 - **Transport**: stdio (default), sse, or streamable-http
 
-## Tools (12)
+## Tools (13)
 
 | Tool | Purpose |
 |------|---------|
@@ -25,6 +25,7 @@ TastyTrade MCP server (Python/FastMCP). Exposes 12 tools for portfolio managemen
 | `list_orders` | List live orders |
 | `get_quotes` | Live streaming quotes (stocks, options, futures, indices) |
 | `get_greeks` | Streaming Greeks for options |
+| `find_strikes_by_delta` | Nearest strikes for target deltas (e.g. IC wings) |
 | `get_market_metrics` | IV rank, beta, liquidity, earnings |
 | `market_status` | Exchange hours, holidays, NYC time |
 | `search_symbols` | Symbol search |

--- a/tasty_agent/server.py
+++ b/tasty_agent/server.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 from datetime import UTC, datetime
 from decimal import Decimal
 from html import escape as escape_xml_text
@@ -53,7 +54,12 @@ logger = logging.getLogger(__name__)
 
 rate_limiter = AsyncLimiter(2, 1)  # 2 requests per second
 
-mcp_app = FastMCP("TastyTrade", lifespan=lifespan)
+mcp_app = FastMCP(
+    "TastyTrade",
+    lifespan=lifespan,
+    host=os.environ.get("FASTMCP_HOST", "127.0.0.1"),
+    port=int(os.environ.get("FASTMCP_PORT", "8000")),
+)
 
 TOOL_XML_TAGS = {
     "get_history": "history",

--- a/tasty_agent/server.py
+++ b/tasty_agent/server.py
@@ -12,6 +12,7 @@ from mcp.server.fastmcp import Context, FastMCP
 from mcp.server.fastmcp.prompts.base import AssistantMessage, Message, UserMessage
 from tastytrade import metrics
 from tastytrade.dxfeed import Greeks, Quote
+from tastytrade.instruments import FutureOption, Option
 from tastytrade.market_sessions import ExchangeType, MarketStatus, get_market_holidays, get_market_sessions
 from tastytrade.order import OrderTimeInForce
 from tastytrade.search import symbol_search
@@ -52,7 +53,6 @@ from tasty_agent.orders import (
     validate_date_format,
 )
 from tasty_agent.strikes import (
-    compact_strike_match,
     find_nearest_strikes_by_delta,
     is_monthly_expiration,
     select_expiration_from_dte_range,
@@ -338,6 +338,23 @@ def _compact_greeks_event(event) -> dict[str, Any]:
     }
 
 
+def compact_strike_match(target: float, option: Option | FutureOption, greek: Greeks) -> dict[str, Any]:
+    """Format one delta-matched strike as a compact table row."""
+    greek_row = _compact_greeks_event(greek)
+    return {
+        "target": target,
+        "sym": greek_row.get("sym"),
+        "strike": compact_value(option.strike_price),
+        "type": option.option_type.value,
+        "delta": greek_row.get("delta"),
+        "price": greek_row.get("price"),
+        "iv": greek_row.get("iv"),
+        "gamma": greek_row.get("gamma"),
+        "theta": greek_row.get("theta"),
+        "vega": greek_row.get("vega"),
+    }
+
+
 def _compact_market_metric(metric) -> dict[str, Any]:
     data = metric.model_dump()
     earnings = getattr(metric, "earnings", None)
@@ -526,7 +543,7 @@ async def find_strikes_by_delta(
     expiration_date: str | None = None,
     min_dte: int | None = None,
     max_dte: int | None = None,
-    timeout: float = 10.0,
+    timeout: float = 60.0,
 ) -> str:
     """
     Find the nearest option strikes for given target deltas.
@@ -557,7 +574,9 @@ async def find_strikes_by_delta(
             to discover available expirations.
         min_dte: Minimum days to expiration (equity options only, requires max_dte).
         max_dte: Maximum days to expiration (equity options only, requires min_dte).
-        timeout: Seconds to wait for DXLink data.
+        timeout: Seconds to wait for DXLink data (default: 60). Full-chain
+            streaming may need more time than a single-strike lookup — this
+            matches the default used by get_gex, which streams the same way.
     """
     validate_target_deltas(target_deltas)
 

--- a/tasty_agent/server.py
+++ b/tasty_agent/server.py
@@ -43,10 +43,20 @@ from tasty_agent.orders import (
     find_live_order,
     format_order_market,
     format_signed_money,
+    get_cached_future_option_chain,
+    get_cached_option_chain,
     get_instrument_details,
     get_option_instrument_details,
     get_order_leg_instrument_details,
     resolve_order_price,
+    validate_date_format,
+)
+from tasty_agent.strikes import (
+    compact_strike_match,
+    find_nearest_strikes_by_delta,
+    is_monthly_expiration,
+    select_expiration_from_dte_range,
+    validate_target_deltas,
 )
 from tasty_agent.watchlists import WatchlistSymbol, manage_watchlist
 
@@ -71,6 +81,7 @@ TOOL_XML_TAGS = {
     "get_greeks": "greeks",
     "get_market_metrics": "market_metrics",
     "search_symbols": "symbol_search",
+    "find_strikes_by_delta": "strikes_by_delta",
 }
 
 
@@ -505,6 +516,98 @@ async def get_greeks(ctx: Context, options: list[OptionSpec], timeout: float = 1
 
     greeks = await _stream_events(session, Greeks, [d.streamer_symbol for d in option_details], timeout)
     return tool_xml("get_greeks", to_table([_compact_greeks_event(greek) for greek in greeks]))
+
+
+@mcp_app.tool()
+async def find_strikes_by_delta(
+    ctx: Context,
+    symbol: str,
+    target_deltas: list[float],
+    expiration_date: str | None = None,
+    min_dte: int | None = None,
+    max_dte: int | None = None,
+    timeout: float = 10.0,
+) -> str:
+    """
+    Find the nearest option strikes for given target deltas.
+
+    Use this to quickly identify strikes at specific delta levels without
+    manually scanning the option chain. Common use case: finding wings for
+    iron condors, credit spreads, or other delta-targeted strategies.
+
+    Sign convention (strict):
+      Positive target -> searches CALLS (e.g. 0.16 finds ~16-delta call)
+      Negative target -> searches PUTS (e.g. -0.16 finds ~16-delta put)
+
+    For iron condor wings on both sides, use [0.16, -0.16].
+    For a single-side credit spread, use [0.30] (call) or [-0.30] (put).
+
+    Alternative to expiration_date: provide min_dte and max_dte to
+    automatically select the best expiration within a DTE range.
+    Prefers standard monthly expirations (3rd Friday) when available,
+    selects closest to center of range.
+    DTE range is for equity options only -- futures require expiration_date.
+    Example: min_dte=35, max_dte=45 for ~40 DTE premium selling.
+
+    Args:
+        symbol: Underlying symbol, e.g. SPY, AAPL, /ES.
+        target_deltas: List of target deltas. Sign determines side
+            (positive=call, negative=put). Example: [0.16, -0.16].
+        expiration_date: YYYY-MM-DD. Use get_greeks with an invalid date
+            to discover available expirations.
+        min_dte: Minimum days to expiration (equity options only, requires max_dte).
+        max_dte: Maximum days to expiration (equity options only, requires min_dte).
+        timeout: Seconds to wait for DXLink data.
+    """
+    validate_target_deltas(target_deltas)
+
+    if expiration_date is None and (min_dte is None or max_dte is None):
+        raise ValueError("Provide expiration_date, or both min_dte and max_dte")
+    if min_dte is not None and max_dte is not None and min_dte > max_dte:
+        raise ValueError(f"min_dte ({min_dte}) must be <= max_dte ({max_dte})")
+
+    session = get_session(ctx)
+    symbol = symbol.upper()
+    is_future = symbol.startswith("/")
+
+    if is_future and expiration_date is None:
+        raise ValueError(
+            "Futures options require explicit expiration_date. "
+            "DTE range (min_dte/max_dte) is supported for equity options only."
+        )
+
+    chain = (
+        await get_cached_future_option_chain(session, symbol)
+        if is_future
+        else await get_cached_option_chain(session, symbol)
+    )
+
+    dte: int | None = None
+    if expiration_date is not None:
+        target_date = validate_date_format(expiration_date)
+        if target_date not in chain:
+            available_dates = sorted(chain.keys())
+            raise ValueError(f"No options found for {symbol} expiration {expiration_date}. Available: {available_dates}")
+    else:
+        assert min_dte is not None and max_dte is not None  # validated above
+        today = now_in_new_york().date()
+        target_date = select_expiration_from_dte_range(sorted(chain.keys()), min_dte, max_dte, today)
+        dte = (target_date - today).days
+
+    options = chain[target_date]
+    streamer_symbols = [option.streamer_symbol for option in options]
+    greeks = await _stream_events(session, Greeks, streamer_symbols, timeout)
+    greeks_by_symbol = {greek.event_symbol: greek for greek in greeks}
+
+    matches = find_nearest_strikes_by_delta(options, greeks_by_symbol, target_deltas)
+    rows = [compact_strike_match(target, option, greek) for target, option, greek in matches]
+    table = to_table(rows)
+
+    if dte is not None:
+        monthly_label = ", monthly" if is_monthly_expiration(target_date) else ""
+        table = f"expiration: {target_date} ({dte} DTE{monthly_label})\n\n{table}"
+
+    return tool_xml("find_strikes_by_delta", table)
 
 
 @mcp_app.tool()

--- a/tasty_agent/strikes.py
+++ b/tasty_agent/strikes.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 from datetime import date, timedelta
-from typing import Any
 
 from tastytrade.dxfeed import Greeks
 from tastytrade.instruments import FutureOption, Option
-
-from tasty_agent.core import compact_value
 
 
 def is_monthly_expiration(expiration: date) -> bool:
@@ -90,20 +87,3 @@ def find_nearest_strikes_by_delta(
         matches.append((target, option, greek))
 
     return matches
-
-
-def compact_strike_match(target: float, option: Option | FutureOption, greek: Greeks) -> dict[str, Any]:
-    """Format one delta-matched strike as a compact table row."""
-    data = greek.model_dump()
-    return {
-        "target": target,
-        "sym": compact_value(data.get("event_symbol")),
-        "strike": compact_value(option.strike_price),
-        "type": option.option_type.value,
-        "delta": compact_value(data.get("delta")),
-        "price": compact_value(data.get("price")),
-        "iv": compact_value(data.get("volatility")),
-        "gamma": compact_value(data.get("gamma")),
-        "theta": compact_value(data.get("theta")),
-        "vega": compact_value(data.get("vega")),
-    }

--- a/tasty_agent/strikes.py
+++ b/tasty_agent/strikes.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+from tastytrade.dxfeed import Greeks
+from tastytrade.instruments import FutureOption, Option
+
+from tasty_agent.core import compact_value
+
+
+def is_monthly_expiration(expiration: date) -> bool:
+    """Return whether expiration is the standard monthly (3rd Friday of its month)."""
+    first = expiration.replace(day=1)
+    friday_offset = (4 - first.weekday()) % 7
+    third_friday = first + timedelta(days=friday_offset + 14)
+    return expiration == third_friday
+
+
+def select_expiration_from_dte_range(
+    available_expirations: list[date],
+    min_dte: int,
+    max_dte: int,
+    today: date,
+) -> date:
+    """Select the best expiration within [min_dte, max_dte] DTE.
+
+    Prefers standard monthly expirations (3rd Friday) closest to the center of
+    the range; falls back to the closest candidate if none are monthly.
+    """
+    min_date = today + timedelta(days=min_dte)
+    max_date = today + timedelta(days=max_dte)
+    candidates = [exp for exp in available_expirations if min_date <= exp <= max_date]
+
+    if not candidates:
+        nearby = sorted(
+            available_expirations,
+            key=lambda exp: min(abs((exp - min_date).days), abs((exp - max_date).days)),
+        )[:5]
+        raise ValueError(
+            f"No expirations found between {min_dte}-{max_dte} DTE. Nearest available: {nearby}"
+        )
+
+    target_date = today + timedelta(days=(min_dte + max_dte) // 2)
+    monthlies = [exp for exp in candidates if is_monthly_expiration(exp)]
+    pool = monthlies or candidates
+    return min(pool, key=lambda exp: abs((exp - target_date).days))
+
+
+def validate_target_deltas(target_deltas: list[float]) -> None:
+    """Validate sign-convention target deltas: positive=call side, negative=put side."""
+    if not target_deltas:
+        raise ValueError("target_deltas is required")
+    for target in target_deltas:
+        if target == 0:
+            raise ValueError(
+                "target_delta = 0 is not valid. Positive targets search calls, negative targets search puts."
+            )
+
+
+def find_nearest_strikes_by_delta(
+    options: list[Option | FutureOption],
+    greeks_by_symbol: dict[str, Greeks],
+    target_deltas: list[float],
+) -> list[tuple[float, Option | FutureOption, Greeks]]:
+    """For each target delta, find the option with the closest delta on the matching side.
+
+    Positive target_delta searches calls (call delta is 0 to 1); negative searches
+    puts (put delta is -1 to 0). Matching minimizes abs(actual_delta - target_delta).
+    """
+    calls = [option for option in options if option.option_type.value == "C"]
+    puts = [option for option in options if option.option_type.value == "P"]
+
+    matches: list[tuple[float, Option | FutureOption, Greeks]] = []
+    for target in target_deltas:
+        side_options = calls if target > 0 else puts
+        side_label = "call" if target > 0 else "put"
+
+        candidates: list[tuple[float, Option | FutureOption, Greeks]] = []
+        for option in side_options:
+            greek = greeks_by_symbol.get(option.streamer_symbol)
+            if greek is None or greek.delta is None:
+                continue
+            candidates.append((abs(float(greek.delta) - target), option, greek))
+
+        if not candidates:
+            raise ValueError(f"No {side_label} strikes with delta data found for target {target}")
+
+        _, option, greek = min(candidates, key=lambda item: item[0])
+        matches.append((target, option, greek))
+
+    return matches
+
+
+def compact_strike_match(target: float, option: Option | FutureOption, greek: Greeks) -> dict[str, Any]:
+    """Format one delta-matched strike as a compact table row."""
+    data = greek.model_dump()
+    return {
+        "target": target,
+        "sym": compact_value(data.get("event_symbol")),
+        "strike": compact_value(option.strike_price),
+        "type": option.option_type.value,
+        "delta": compact_value(data.get("delta")),
+        "price": compact_value(data.get("price")),
+        "iv": compact_value(data.get("volatility")),
+        "gamma": compact_value(data.get("gamma")),
+        "theta": compact_value(data.get("theta")),
+        "vega": compact_value(data.get("vega")),
+    }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -48,11 +48,18 @@ from tasty_agent.server import (
     _compact_greeks_event,
     _compact_market_metric,
     _compact_quote_event,
+    find_strikes_by_delta,
     get_greeks,
     market_status,
     place_order,
     replace_order,
     tool_xml,
+)
+from tasty_agent.strikes import (
+    find_nearest_strikes_by_delta,
+    is_monthly_expiration,
+    select_expiration_from_dte_range,
+    validate_target_deltas,
 )
 from tasty_agent.watchlists import WatchlistSymbol, _compact_watchlist
 
@@ -385,6 +392,313 @@ class TestGreeksTool:
         assert stream.await_args.args[3] == 3.0
         assert "./ESM6 C5800" in result
         assert "<greeks>" in result
+
+
+def _make_greek(event_symbol: str, delta: str, price: str = "1.00", volatility: str = "0.15", gamma: str = "0.01", theta: str = "-0.05", vega: str = "0.10"):
+    greek = Mock()
+    greek.event_symbol = event_symbol
+    greek.delta = Decimal(delta)
+    greek.model_dump.return_value = {
+        "event_symbol": event_symbol,
+        "price": Decimal(price),
+        "volatility": Decimal(volatility),
+        "delta": Decimal(delta),
+        "gamma": Decimal(gamma),
+        "theta": Decimal(theta),
+        "vega": Decimal(vega),
+    }
+    return greek
+
+
+def _make_option(streamer_symbol: str, option_type: OptionType, strike_price: str):
+    return Option.model_construct(
+        instrument_type=InstrumentType.EQUITY_OPTION,
+        symbol=streamer_symbol,
+        streamer_symbol=streamer_symbol,
+        underlying_symbol="SPY",
+        option_type=option_type,
+        strike_price=Decimal(strike_price),
+        expiration_date=date(2026, 7, 17),
+    )
+
+
+class TestValidateTargetDeltas:
+    """Tests for target-delta sign-convention validation."""
+
+    def test_empty_list_raises_error(self):
+        with pytest.raises(ValueError, match="target_deltas is required"):
+            validate_target_deltas([])
+
+    def test_zero_delta_raises_error(self):
+        with pytest.raises(ValueError, match="target_delta = 0 is not valid"):
+            validate_target_deltas([0.16, 0])
+
+    def test_valid_positive_and_negative_pass(self):
+        validate_target_deltas([0.16, -0.16, 0.5, -0.5])
+
+
+class TestFindNearestStrikesByDelta:
+    """Tests for the core delta-matching logic used by find_strikes_by_delta."""
+
+    def test_positive_target_matches_nearest_call(self):
+        call_785 = _make_option(".SPY260717C785", OptionType.CALL, "785")
+        call_790 = _make_option(".SPY260717C790", OptionType.CALL, "790")
+        put_710 = _make_option(".SPY260717P710", OptionType.PUT, "710")
+        greeks_by_symbol = {
+            ".SPY260717C785": _make_greek(".SPY260717C785", "0.148"),
+            ".SPY260717C790": _make_greek(".SPY260717C790", "0.120"),
+            ".SPY260717P710": _make_greek(".SPY260717P710", "-0.178"),
+        }
+
+        matches = find_nearest_strikes_by_delta([call_785, call_790, put_710], greeks_by_symbol, [0.16])
+
+        assert len(matches) == 1
+        target, option, greek = matches[0]
+        assert target == 0.16
+        assert option is call_785
+        assert greek.delta == Decimal("0.148")
+
+    def test_negative_target_matches_nearest_put_only(self):
+        call_785 = _make_option(".SPY260717C785", OptionType.CALL, "785")
+        put_710 = _make_option(".SPY260717P710", OptionType.PUT, "710")
+        put_705 = _make_option(".SPY260717P705", OptionType.PUT, "705")
+        greeks_by_symbol = {
+            ".SPY260717C785": _make_greek(".SPY260717C785", "0.148"),
+            ".SPY260717P710": _make_greek(".SPY260717P710", "-0.178"),
+            ".SPY260717P705": _make_greek(".SPY260717P705", "-0.155"),
+        }
+
+        matches = find_nearest_strikes_by_delta([call_785, put_710, put_705], greeks_by_symbol, [-0.16])
+
+        assert len(matches) == 1
+        target, option, greek = matches[0]
+        assert target == -0.16
+        assert option is put_705
+        assert greek.delta == Decimal("-0.155")
+
+    def test_both_wings_for_iron_condor(self):
+        call_785 = _make_option(".SPY260717C785", OptionType.CALL, "785")
+        put_710 = _make_option(".SPY260717P710", OptionType.PUT, "710")
+        greeks_by_symbol = {
+            ".SPY260717C785": _make_greek(".SPY260717C785", "0.148"),
+            ".SPY260717P710": _make_greek(".SPY260717P710", "-0.178"),
+        }
+
+        matches = find_nearest_strikes_by_delta([call_785, put_710], greeks_by_symbol, [0.16, -0.16])
+
+        assert [m[0] for m in matches] == [0.16, -0.16]
+        assert matches[0][1] is call_785
+        assert matches[1][1] is put_710
+
+    def test_atm_delta_returns_correct_strike_without_crashing(self):
+        call_atm = _make_option(".SPY260717C750", OptionType.CALL, "750")
+        put_atm = _make_option(".SPY260717P750", OptionType.PUT, "750")
+        greeks_by_symbol = {
+            ".SPY260717C750": _make_greek(".SPY260717C750", "0.503"),
+            ".SPY260717P750": _make_greek(".SPY260717P750", "-0.497"),
+        }
+
+        matches = find_nearest_strikes_by_delta([call_atm, put_atm], greeks_by_symbol, [0.5, -0.5])
+
+        assert matches[0][1] is call_atm
+        assert matches[1][1] is put_atm
+
+    def test_missing_delta_data_raises_error(self):
+        call_785 = _make_option(".SPY260717C785", OptionType.CALL, "785")
+
+        with pytest.raises(ValueError, match="No call strikes with delta data found"):
+            find_nearest_strikes_by_delta([call_785], {}, [0.16])
+
+
+class TestIsMonthlyExpiration:
+    """Tests for standard-monthly (3rd Friday) expiration detection."""
+
+    def test_third_friday_is_monthly(self):
+        assert is_monthly_expiration(date(2026, 7, 17)) is True
+
+    def test_other_friday_is_not_monthly(self):
+        assert is_monthly_expiration(date(2026, 7, 10)) is False
+        assert is_monthly_expiration(date(2026, 7, 24)) is False
+
+
+class TestSelectExpirationFromDteRange:
+    """Tests for DTE-range expiration selection with monthly preference."""
+
+    def test_prefers_monthly_closest_to_center(self):
+        today = date(2026, 6, 12)
+        available = [date(2026, 7, 10), date(2026, 7, 17), date(2026, 7, 24)]
+
+        selected = select_expiration_from_dte_range(available, min_dte=25, max_dte=45, today=today)
+
+        assert selected == date(2026, 7, 17)
+
+    def test_falls_back_to_closest_to_center_when_no_monthly(self):
+        today = date(2026, 6, 12)
+        available = [date(2026, 7, 10), date(2026, 7, 24)]
+
+        selected = select_expiration_from_dte_range(available, min_dte=25, max_dte=32, today=today)
+
+        assert selected == date(2026, 7, 10)
+
+    def test_no_candidates_raises_error_with_nearest_alternatives(self):
+        today = date(2026, 6, 12)
+        available = [date(2026, 7, 17)]
+
+        with pytest.raises(ValueError, match="No expirations found between 1-5 DTE"):
+            select_expiration_from_dte_range(available, min_dte=1, max_dte=5, today=today)
+
+
+class TestFindStrikesByDeltaTool:
+    """Tests for find_strikes_by_delta tool orchestration."""
+
+    @pytest.mark.asyncio
+    async def test_returns_matched_strikes_for_both_signs_with_explicit_expiration(self):
+        session = Mock()
+        mock_ctx = Mock()
+        mock_ctx.request_context = Mock()
+        mock_ctx.request_context.lifespan_context = SimpleNamespace(session=session)
+
+        call_785 = _make_option(".SPY260717C785", OptionType.CALL, "785")
+        put_710 = _make_option(".SPY260717P710", OptionType.PUT, "710")
+        chain = {date(2026, 7, 17): [call_785, put_710]}
+        greeks = [
+            _make_greek(".SPY260717C785", "0.148"),
+            _make_greek(".SPY260717P710", "-0.178"),
+        ]
+
+        with (
+            patch("tasty_agent.server.get_cached_option_chain", new=AsyncMock(return_value=chain)) as chain_mock,
+            patch("tasty_agent.server._stream_events", new=AsyncMock(return_value=greeks)) as stream_mock,
+        ):
+            result = await find_strikes_by_delta(
+                mock_ctx, "spy", [0.16, -0.16], expiration_date="2026-07-17", timeout=3.0
+            )
+
+        chain_mock.assert_awaited_once_with(session, "SPY")
+        stream_mock.assert_awaited_once()
+        assert stream_mock.await_args.args[0] is session
+        assert set(stream_mock.await_args.args[2]) == {".SPY260717C785", ".SPY260717P710"}
+        assert stream_mock.await_args.args[3] == 3.0
+        assert "<strikes_by_delta>" in result
+        assert ".SPY260717C785" in result
+        assert ".SPY260717P710" in result
+        assert "expiration:" not in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_expiration_lists_available_dates(self):
+        session = Mock()
+        mock_ctx = Mock()
+        mock_ctx.request_context = Mock()
+        mock_ctx.request_context.lifespan_context = SimpleNamespace(session=session)
+
+        chain = {date(2026, 7, 17): []}
+
+        with (
+            patch("tasty_agent.server.get_cached_option_chain", new=AsyncMock(return_value=chain)),
+            pytest.raises(ValueError, match=r"Available: \[.*2026, 7, 17.*\]"),
+        ):
+            await find_strikes_by_delta(mock_ctx, "SPY", [0.16], expiration_date="2026-08-21")
+
+    @pytest.mark.asyncio
+    async def test_zero_target_delta_rejected_before_fetching_chain(self):
+        mock_ctx = Mock()
+
+        with (
+            patch("tasty_agent.server.get_cached_option_chain", new=AsyncMock()) as chain_mock,
+            pytest.raises(ValueError, match="target_delta = 0 is not valid"),
+        ):
+            await find_strikes_by_delta(mock_ctx, "SPY", [0], expiration_date="2026-07-17")
+
+        chain_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_expiration_and_dte_range_raises_error(self):
+        mock_ctx = Mock()
+
+        with pytest.raises(ValueError, match="Provide expiration_date, or both min_dte and max_dte"):
+            await find_strikes_by_delta(mock_ctx, "SPY", [0.16])
+
+    @pytest.mark.asyncio
+    async def test_min_dte_greater_than_max_dte_raises_error(self):
+        mock_ctx = Mock()
+
+        with pytest.raises(ValueError, match=r"min_dte \(45\) must be <= max_dte \(35\)"):
+            await find_strikes_by_delta(mock_ctx, "SPY", [0.16], min_dte=45, max_dte=35)
+
+    @pytest.mark.asyncio
+    async def test_futures_without_expiration_date_rejects_dte_range(self):
+        mock_ctx = Mock()
+
+        with (
+            patch("tasty_agent.server.get_cached_future_option_chain", new=AsyncMock()) as chain_mock,
+            pytest.raises(ValueError, match="Futures options require explicit expiration_date"),
+        ):
+            await find_strikes_by_delta(mock_ctx, "/ES", [0.16], min_dte=35, max_dte=45)
+
+        chain_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_dte_range_selects_monthly_and_prefixes_expiration_header(self):
+        session = Mock()
+        mock_ctx = Mock()
+        mock_ctx.request_context = Mock()
+        mock_ctx.request_context.lifespan_context = SimpleNamespace(session=session)
+
+        weekly_exp = date(2026, 7, 10)
+        monthly_exp = date(2026, 7, 17)
+        call = _make_option(".SPY260717C785", OptionType.CALL, "785")
+        chain = {
+            weekly_exp: [call],
+            monthly_exp: [call],
+        }
+        greeks = [_make_greek(".SPY260717C785", "0.148")]
+
+        with (
+            patch("tasty_agent.server.get_cached_option_chain", new=AsyncMock(return_value=chain)),
+            patch("tasty_agent.server._stream_events", new=AsyncMock(return_value=greeks)),
+            patch("tasty_agent.server.now_in_new_york", return_value=datetime(2026, 6, 12, 12, 0)),
+        ):
+            result = await find_strikes_by_delta(mock_ctx, "SPY", [0.16], min_dte=25, max_dte=45)
+
+        assert "expiration: 2026-07-17 (35 DTE, monthly)" in result
+
+    @pytest.mark.asyncio
+    async def test_dte_range_falls_back_to_closest_when_no_monthly(self):
+        session = Mock()
+        mock_ctx = Mock()
+        mock_ctx.request_context = Mock()
+        mock_ctx.request_context.lifespan_context = SimpleNamespace(session=session)
+
+        weekly_exp = date(2026, 7, 10)
+        call = _make_option(".SPY260710C785", OptionType.CALL, "785")
+        chain = {weekly_exp: [call]}
+        greeks = [_make_greek(".SPY260710C785", "0.148")]
+
+        with (
+            patch("tasty_agent.server.get_cached_option_chain", new=AsyncMock(return_value=chain)),
+            patch("tasty_agent.server._stream_events", new=AsyncMock(return_value=greeks)),
+            patch("tasty_agent.server.now_in_new_york", return_value=datetime(2026, 6, 12, 12, 0)),
+        ):
+            result = await find_strikes_by_delta(mock_ctx, "SPY", [0.16], min_dte=25, max_dte=32)
+
+        assert "expiration: 2026-07-10 (28 DTE)" in result
+        assert "monthly" not in result
+
+    @pytest.mark.asyncio
+    async def test_no_expirations_in_dte_range_lists_nearest_alternatives(self):
+        session = Mock()
+        mock_ctx = Mock()
+        mock_ctx.request_context = Mock()
+        mock_ctx.request_context.lifespan_context = SimpleNamespace(session=session)
+
+        chain = {date(2026, 7, 17): []}
+
+        with (
+            patch("tasty_agent.server.get_cached_option_chain", new=AsyncMock(return_value=chain)),
+            patch("tasty_agent.server.now_in_new_york", return_value=datetime(2026, 6, 12, 12, 0)),
+            pytest.raises(ValueError, match="No expirations found between 1-5 DTE"),
+        ):
+            await find_strikes_by_delta(mock_ctx, "SPY", [0.16], min_dte=1, max_dte=5)
 
 
 class TestOrderTools:


### PR DESCRIPTION
## What

- `compact_strike_match` now builds its row from `_compact_greeks_event(greek)`
  instead of duplicating the individual `compact_value(...)` calls for each
  Greek field. Moved from `tasty_agent/strikes.py` into `tasty_agent/server.py`,
  placed right after `_compact_greeks_event` since it now depends on it.
- `find_strikes_by_delta`'s `timeout` default changed from 10.0 to 60.0.

## Why

Full-chain Greek streaming (200+ strikes for liquid symbols like SPY) needs
more time than a single-strike `get_greeks` lookup — 60s matches the
precedent for that kind of full-chain streaming. Reusing
`_compact_greeks_event` avoids two near-identical implementations of the
same field-compaction logic drifting apart over time.

## How

- `tasty_agent/strikes.py`: removed `compact_strike_match` and the
  now-unused `Any` / `compact_value` imports. `is_monthly_expiration`,
  `select_expiration_from_dte_range`, `validate_target_deltas`, and
  `find_nearest_strikes_by_delta` are unchanged.
- `tasty_agent/server.py`: added the `Option`/`FutureOption` import, added
  `compact_strike_match` (reusing `_compact_greeks_event`), dropped it from
  the `tasty_agent.strikes` import list.

Column order is unchanged: target, sym, strike, type, delta, price, iv,
gamma, theta, vega.

## Testing

- `uv run pytest`: 104 passed, 11 skipped — unchanged, no test updates
  needed since `compact_strike_match` is only exercised indirectly through
  `find_strikes_by_delta`.
- `ruff check` and `pyright` clean on both changed files.